### PR TITLE
Add meson build system

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,11 @@
+project('zypak', 'cpp',
+  version : '2021.06',
+  default_options : ['warning_level=3', 'cpp_std=c++17'])
+
+libsystemd_dep = dependency('libsystemd')
+dbus_dep = dependency('dbus-1')
+threads_dep = dependency('threads')
+
+nickle_dir = include_directories('nickle')
+
+subdir('src')

--- a/src/base/meson.build
+++ b/src/base/meson.build
@@ -1,0 +1,16 @@
+sources = [
+    'debug_internal/log_stream.cc',
+    'debug.cc',
+    'env.cc',
+    'evloop.cc',
+    'fd_map.cc',
+    'socket.cc',
+    'strace.cc'
+]
+
+zypak_base = static_library(
+    'zypak-base',
+    sources,
+    include_directories: [src_dir],
+    dependencies: [libsystemd_dep]
+)

--- a/src/dbus/meson.build
+++ b/src/dbus/meson.build
@@ -1,0 +1,15 @@
+sources = [
+    'bus.cc',
+    'bus_error.cc',
+    'bus_readable_message.cc',
+    'bus_writable_message.cc',
+    'flatpak_portal_proxy.cc',
+    'internal/bus_thread.cc'
+]
+
+zypak_dbus = static_library(
+    'zypak-dbus',
+    sources,
+    include_directories: [src_dir],
+    dependencies: [dbus_dep]
+)

--- a/src/helper/meson.build
+++ b/src/helper/meson.build
@@ -1,0 +1,14 @@
+sources = [
+    'chroot_helper.cc',
+    'main.cc',
+    'spawn_latest.cc'
+]
+
+zypak_helper = executable(
+    'zypak-helper',
+    sources,
+    include_directories: [src_dir],
+    dependencies: [threads_dep, dbus_dep],
+    link_with: [zypak_base, zypak_dbus],
+    install: true
+)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,7 @@
+src_dir = include_directories('.')
+
+subdir('base')
+subdir('dbus')
+subdir('preload')
+subdir('sandbox')
+subdir('helper')

--- a/src/preload/child/meson.build
+++ b/src/preload/child/meson.build
@@ -1,0 +1,15 @@
+sources = [
+    'bwrap_pid.cc'
+]
+
+zypak_preload_host = shared_library(
+    'zypak-preload-child',
+    sources,
+    include_directories: [src_dir],
+    dependencies: [dl_dep],
+    link_with: [zypak_base],
+    install: true
+)
+
+subdir('spawn_strategy')
+subdir('mimic_strategy')

--- a/src/preload/child/mimic_strategy/meson.build
+++ b/src/preload/child/mimic_strategy/meson.build
@@ -1,0 +1,15 @@
+sources = [
+    'fd_storage.cc',
+    'initialize.cc',
+    'localtime.cc',
+    'open_urandom.cc',
+]
+
+zypak_preload_child_spawn_strategy = shared_library(
+    'zypak-preload-child-mimic-strategy',
+    sources,
+    include_directories: [src_dir, nickle_dir],
+    dependencies: [dl_dep],
+    link_with: [zypak_base],
+    install: true
+)

--- a/src/preload/child/spawn_strategy/meson.build
+++ b/src/preload/child/spawn_strategy/meson.build
@@ -1,0 +1,12 @@
+sources = [
+    'chroot_fake.cc'
+]
+
+zypak_preload_child_spawn_strategy = shared_library(
+    'zypak-preload-child-spawn-strategy',
+    sources,
+    include_directories: [src_dir],
+    dependencies: [dl_dep, dbus_dep],
+    link_with: [zypak_base, zypak_dbus],
+    install: true
+)

--- a/src/preload/host/meson.build
+++ b/src/preload/host/meson.build
@@ -1,0 +1,16 @@
+sources = [
+    'exec_zypak_sandbox.cc',
+    'sandbox_path.cc',
+    'sandbox_suid.cc'
+]
+
+zypak_preload_host = shared_library(
+    'zypak-preload-host',
+    sources,
+    include_directories: [src_dir],
+    dependencies: [dl_dep],
+    link_with: [zypak_base],
+    install: true
+)
+
+subdir('spawn_strategy')

--- a/src/preload/host/spawn_strategy/meson.build
+++ b/src/preload/host/spawn_strategy/meson.build
@@ -1,0 +1,17 @@
+sources = [
+    'bus_safe_fork.cc',
+    'initialize.cc',
+    'no_close_host_fd.cc',
+    'process_override.cc',
+    'spawn_request.cc',
+    'supervisor.cc'
+]
+
+zypak_preload_host_spawn_strategy = shared_library(
+    'zypak-preload-host-spawn-strategy',
+    sources,
+    include_directories: [src_dir, nickle_dir],
+    dependencies: [dl_dep, threads_dep, dbus_dep],
+    link_with: [zypak_base, zypak_dbus],
+    install: true
+)

--- a/src/preload/meson.build
+++ b/src/preload/meson.build
@@ -1,0 +1,4 @@
+dl_dep = meson.get_compiler('cpp').find_library('dl')
+
+subdir('host')
+subdir('child')

--- a/src/sandbox/meson.build
+++ b/src/sandbox/meson.build
@@ -1,0 +1,20 @@
+sources = [
+    'launcher.cc',
+    'main.cc',
+    'mimic_strategy/fork.cc',
+    'mimic_strategy/mimic_launcher_delegate.cc',
+    'mimic_strategy/reap.cc',
+    'mimic_strategy/status.cc',
+    'mimic_strategy/zygote.cc',
+    'spawn_strategy/run.cc',
+    'spawn_strategy/spawn_launcher_delegate.cc'
+]
+
+zypak_sandbox = executable(
+    'zypak-sandbox',
+    sources,
+    include_directories: [src_dir, nickle_dir],
+    dependencies: [dbus_dep],
+    link_with: [zypak_base],
+    install: true
+)


### PR DESCRIPTION
This allows building zypak with meson. Potentially it could allow more flexible build-time configuration, but in scope of this PR only basic build was added. Tested with Chrome and VSCode.