### PR TITLE
Added missing quirks library to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,3 +151,4 @@ install : all
 	install -Dm 755 -t $(FLATPAK_DEST)/lib build/libzypak-preload-child.so
 	install -Dm 755 -t $(FLATPAK_DEST)/lib build/libzypak-preload-child-mimic-strategy.so
 	install -Dm 755 -t $(FLATPAK_DEST)/lib build/libzypak-preload-child-spawn-strategy.so
+	install -Dm 755 -t $(FLATPAK_DEST)/lib build/libzypak-preload-quirks-webex-trampoline.so


### PR DESCRIPTION
Makefile didn't include required library for zypak quirks to work, so i added it

After that fix, webex app launches and "works" (not tested fully yet), related to #14 