### PR TITLE
Add a few extra hardening CXXFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ CXX := g++
 CXXFLAGS := \
 		-DZYPAK_RELEASE="\"$(shell git describe --tags --dirty)\"" \
 		-fstack-protector-all -fstack-clash-protection -Wall -Werror \
+		-fno-delete-null-pointer-checks -ftrivial-auto-var-init=zero \
+		-Og -D_FORTIFY_SOURCE=2 -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack \
 		-std=c++20 -g -pthread \
 		-Inickle -Isrc \
 		$(LIBSYSTEMD_CFLAGS) $(DBUS_CFLAGS)


### PR DESCRIPTION
Adds some extra hardening compiler flags, most of them also commonly used in chromium

`-fno-delete-null-pointer-checks`: Make sure the compiler does not optimize away null pointer checks

`-ftrivial-auto-var-init=zero`: Automatically initialize uninitialized auto variables to zero

`-Og -D_FORTIFY_SOURCE=2`: Add bounds checking to insecure string handling functions, `-Og` is the minimum required optimization set to enable FORTIFY_SOURCE, and also helps with debugging. `-O2` would be nicer but probably negatively affects debugging

`-Wl,-z,relro -Wl,-z,now`: Enable Full RELRO support

`-Wl,-z,noexecstack`: Mark stack as non-executable 

adding `-fPIE -pie` to the executables to take full advantage of ASLR would also be nice however im not good enough at makefile for that. The `.so` objects already use full ASLR with `-fPIC` so those are fine